### PR TITLE
fix: map uwallet to p2m in Detail23 and accept all UPayments types

### DIFF
--- a/app/services/by_design_payment_service.rb
+++ b/app/services/by_design_payment_service.rb
@@ -6,19 +6,17 @@ class ByDesignPaymentService
   # HTTP timeout in seconds
   DEFAULT_TIMEOUT = 30
 
-  # Supported payment types - explicitly enumerated for clarity
+  # Known payment types for type-specific behavior (card fields, cash pending)
   CARD_PAYMENT_TYPE = "LOAD_FUNDS_VIA_CARD"
   CASH_PAYMENT_TYPE = "LOAD_FUNDS_VIA_CASH"
-  WALLET_PAYMENT_TYPES = %w[UWALLET_TRANSFER uwallet].freeze
-  SUPPORTED_PAYMENT_TYPES = ([ CARD_PAYMENT_TYPE, CASH_PAYMENT_TYPE ] + WALLET_PAYMENT_TYPES).freeze
 
-  # Payment type mapping from Moola to ByDesign
-  # All Moola payments use CreditCardAccountId 30
-  PAYMENT_TYPE_MAP = {
-    CARD_PAYMENT_TYPE => { credit_card_account_id: 30, description: "Moola Card Payment" },
-    "UWALLET_TRANSFER" => { credit_card_account_id: 30, description: "Moola Wallet Transfer" },
-    "uwallet" => { credit_card_account_id: 30, description: "Moola Wallet" },
-    CASH_PAYMENT_TYPE => { credit_card_account_id: 30, description: "Moola Cash Payment" },
+  # All Moola/UPayments types use the same CreditCardAccountId
+  DEFAULT_CREDIT_CARD_ACCOUNT_ID = 30
+
+  # Detail23 type mapping - maps webhook types to Freedom display labels.
+  # Most types pass through as-is (lowercased). Special cases documented here.
+  DETAIL23_TYPE_MAP = {
+    "uwallet" => "p2m",  # Freedom SQL maps "p2m" to "UWallet" label
   }.freeze
 
   # Payment status mapping based on Moola guide:
@@ -110,21 +108,13 @@ class ByDesignPaymentService
       payment_detail["status"] == "Declined"
     end
 
-    # Payment type check methods - explicitly identify each payment type
+    # Payment type check methods - identify types needing special handling
     def card_payment?(payment_type)
       payment_type == CARD_PAYMENT_TYPE
     end
 
     def cash_payment?(payment_type)
       payment_type == CASH_PAYMENT_TYPE
-    end
-
-    def wallet_payment?(payment_type)
-      WALLET_PAYMENT_TYPES.include?(payment_type)
-    end
-
-    def supported_payment_type?(payment_type)
-      SUPPORTED_PAYMENT_TYPES.include?(payment_type)
     end
   end
 
@@ -188,26 +178,17 @@ private
     # Add type-specific fields based on the payment type
     if self.class.card_payment?(payment_type)
       add_card_payment_fields(payload, payment_detail, card_details)
-    elsif self.class.cash_payment?(payment_type)
-      # Cash payments use base payload only - no additional fields
-      Rails.logger.debug("[ByDesignPaymentService] Processing cash payment: #{payment_detail['id']}")
-    elsif self.class.wallet_payment?(payment_type)
-      # Wallet payments use base payload only - no additional fields
-      Rails.logger.debug("[ByDesignPaymentService] Processing wallet payment: #{payment_detail['id']}")
+    else
+      # Non-card payments (cash, wallet, credit_points, etc.) use base payload only
+      Rails.logger.debug("[ByDesignPaymentService] Processing #{payment_type} payment: #{payment_detail['id']}")
     end
 
     payload
   end
 
-  def get_payment_type_config(payment_type)
-    unless self.class.supported_payment_type?(payment_type)
-      Rails.logger.warn("[ByDesignPaymentService] Unknown payment type '#{payment_type}', defaulting to wallet configuration")
-    end
-
-    # Explicit lookup - only use default for truly unknown types
-    PAYMENT_TYPE_MAP.fetch(payment_type) do
-      PAYMENT_TYPE_MAP["UWALLET_TRANSFER"]
-    end
+  def get_payment_type_config(_payment_type)
+    # All UPayments types use the same CreditCardAccountId
+    { credit_card_account_id: DEFAULT_CREDIT_CARD_ACCOUNT_ID }
   end
 
   def build_base_payload(order_id, payment_detail, p2m_data, type_config, kyc_status)
@@ -253,12 +234,13 @@ private
     payment_detail["order_reference"].presence || p2m_data["order_reference"]
   end
 
-  # Normalize payment type to lowercase with underscores (per API docs examples)
+  # Normalize payment type to lowercase, applying Detail23 type mapping where needed.
+  # Most types pass through as-is (lowercased). Special cases are in DETAIL23_TYPE_MAP.
   def normalize_payment_type(payment_type)
     return nil unless payment_type.present?
 
-    # API docs show lowercase: "load_funds_via_card", "uwallet_transfer", "uwallet"
-    payment_type.downcase
+    lowered = payment_type.downcase
+    DETAIL23_TYPE_MAP[lowered] || lowered
   end
 
   # Get payment date from webhook completed_at or use current time

--- a/test/jobs/by_design_payment_recording_job_test.rb
+++ b/test/jobs/by_design_payment_recording_job_test.rb
@@ -261,9 +261,9 @@ describe ByDesignPaymentRecordingJob do
       _(request_body["ProfileIDUsedForProcessor"]).must_equal "94d15bf3-0518-4a53-ab0b-e7b8c7d797e0"
       _(request_body["ProcessorSpecificDetail1"]).must_equal "NULF-CT:p2m-mapping-test"  # invoice_number
       _(request_body["ProcessorSpecificDetail2"]).must_equal "G2XYS6ZBBZ"   # autoship_reference
-      _(request_body["ProcessorSpecificDetail3"]).must_equal "uwallet"      # payment type (lowercase)
+      _(request_body["ProcessorSpecificDetail3"]).must_equal "p2m"           # uwallet maps to p2m
       _(request_body["ProcessorSpecificDetail4"]).must_equal "TKW2BRL2OP"   # order_reference
-      _(request_body["ProcessorSpecificDetail23"]).must_equal "uwallet"    # Detail23: Freedom payment type label
+      _(request_body["ProcessorSpecificDetail23"]).must_equal "p2m"        # Detail23: Freedom maps p2m to UWallet label
     end
 
     it "sends correct card fields for LOAD_FUNDS_VIA_CARD payments" do

--- a/test/services/by_design_payment_service_test.rb
+++ b/test/services/by_design_payment_service_test.rb
@@ -338,7 +338,7 @@ describe ByDesignPaymentService do
         _(payload[:ProcessorSpecificDetail2]).must_equal "G2XYS6ZBBZ"       # autoship_reference
         _(payload[:ProcessorSpecificDetail3]).must_equal "p2m"               # uwallet maps to p2m
         _(payload[:ProcessorSpecificDetail4]).must_equal "TKW2BRL2OP"       # order_reference
-        _(payload[:ProcessorSpecificDetail23]).must_equal "p2m"             # Detail23: Freedom maps p2m to UWallet label
+        _(payload[:ProcessorSpecificDetail23]).must_equal "p2m"            # Detail23: Freedom maps p2m to UWallet
       end
 
       it "uses promissory amount for Pending payments" do

--- a/test/services/by_design_payment_service_test.rb
+++ b/test/services/by_design_payment_service_test.rb
@@ -61,20 +61,6 @@ describe ByDesignPaymentService do
       _(ByDesignPaymentService.cash_payment?("LOAD_FUNDS_VIA_CASH")).must_equal true
       _(ByDesignPaymentService.cash_payment?("uwallet")).must_equal false
     end
-
-    it "identifies wallet payments" do
-      _(ByDesignPaymentService.wallet_payment?("uwallet")).must_equal true
-      _(ByDesignPaymentService.wallet_payment?("UWALLET_TRANSFER")).must_equal true
-      _(ByDesignPaymentService.wallet_payment?("LOAD_FUNDS_VIA_CARD")).must_equal false
-    end
-
-    it "identifies supported payment types" do
-      _(ByDesignPaymentService.supported_payment_type?("LOAD_FUNDS_VIA_CARD")).must_equal true
-      _(ByDesignPaymentService.supported_payment_type?("LOAD_FUNDS_VIA_CASH")).must_equal true
-      _(ByDesignPaymentService.supported_payment_type?("uwallet")).must_equal true
-      _(ByDesignPaymentService.supported_payment_type?("UWALLET_TRANSFER")).must_equal true
-      _(ByDesignPaymentService.supported_payment_type?("UNKNOWN_TYPE")).must_equal false
-    end
   end
 
   describe "#record_payment" do
@@ -156,8 +142,8 @@ describe ByDesignPaymentService do
           !body.key?("PaymentToken") &&
           !body.key?("Last4CCNumber") &&
           !body.key?("ExpirationDateMMYY") &&
-          body["ProcessorSpecificDetail3"] == "uwallet" &&
-          body["ProcessorSpecificDetail23"] == "uwallet"
+          body["ProcessorSpecificDetail3"] == "p2m" &&
+          body["ProcessorSpecificDetail23"] == "p2m"
         }
         .to_return(
           status: 200,
@@ -350,9 +336,9 @@ describe ByDesignPaymentService do
         # Processor-specific fields
         _(payload[:ProcessorSpecificDetail1]).must_equal "NULF-CT:test123"  # invoice_number
         _(payload[:ProcessorSpecificDetail2]).must_equal "G2XYS6ZBBZ"       # autoship_reference
-        _(payload[:ProcessorSpecificDetail3]).must_equal "uwallet"          # payment type (lowercase)
+        _(payload[:ProcessorSpecificDetail3]).must_equal "p2m"               # uwallet maps to p2m
         _(payload[:ProcessorSpecificDetail4]).must_equal "TKW2BRL2OP"       # order_reference
-        _(payload[:ProcessorSpecificDetail23]).must_equal "uwallet"         # Detail23: Freedom payment type label
+        _(payload[:ProcessorSpecificDetail23]).must_equal "p2m"             # Detail23: Freedom maps p2m to UWallet label
       end
 
       it "uses promissory amount for Pending payments" do
@@ -459,7 +445,18 @@ describe ByDesignPaymentService do
       it "converts payment type to lowercase" do
         _(service.send(:normalize_payment_type, "LOAD_FUNDS_VIA_CARD")).must_equal "load_funds_via_card"
         _(service.send(:normalize_payment_type, "UWALLET_TRANSFER")).must_equal "uwallet_transfer"
-        _(service.send(:normalize_payment_type, "uwallet")).must_equal "uwallet"
+      end
+
+      it "maps uwallet to p2m for Freedom SQL compatibility" do
+        _(service.send(:normalize_payment_type, "uwallet")).must_equal "p2m"
+        _(service.send(:normalize_payment_type, "UWALLET")).must_equal "p2m"
+      end
+
+      it "passes through other types as-is (lowercased)" do
+        _(service.send(:normalize_payment_type, "credit_points")).must_equal "credit_points"
+        _(service.send(:normalize_payment_type, "QUALIFYING_CREDIT")).must_equal "qualifying_credit"
+        _(service.send(:normalize_payment_type, "pay_by_installment")).must_equal "pay_by_installment"
+        _(service.send(:normalize_payment_type, "DISCOUNT_TRANSACTION")).must_equal "discount_transaction"
       end
 
       it "returns nil for blank input" do


### PR DESCRIPTION
## Summary
- Maps `uwallet` payment type to `p2m` in `ProcessorSpecificDetail23` to match Freedom's SQL label mapping (`p2m` → "UWallet")
- Removes the restrictive `SUPPORTED_PAYMENT_TYPES` list — all UPayments types now pass through to Detail23 as-is (lowercased), supporting `credit_points`, `qualifying_credit`, `pay_by_installment`, `load_funds_via_ach`, `DISCOUNT_TRANSACTION`, etc.
- Simplifies `get_payment_type_config` since all types use the same `CreditCardAccountId: 30`

## Context
Client reported payment types not mapping correctly in Freedom for an order with 4 different payment types. Freedom uses a SQL `CASE WHEN` on `Detail23` to determine payment type labels. The `uwallet` type was being sent as `"uwallet"` but Freedom's SQL expects `"p2m"` for the UWallet label. This matches the ByDesign API doc examples which also use `"p2m"` for uwallet-type payments.

Additionally, UPayments can send many more types than the 4 we previously whitelisted. Per client instruction: "you just need to pass what U-wallet provides you."

## Test plan
- [x] All 53 tests pass (42 service + 11 job)
- [ ] Verify `uwallet` type payments show as "UWallet" in Freedom after deploy
- [ ] Verify `load_funds_via_card`, `uwallet_transfer`, `load_funds_via_cash` continue mapping correctly
- [ ] Test with an order containing multiple payment types

🤖 Generated with [Claude Code](https://claude.com/claude-code)