### PR TITLE
feat: post order to ByDesign after successful payment recording

### DIFF
--- a/app/jobs/by_design_payment_recording_job.rb
+++ b/app/jobs/by_design_payment_recording_job.rb
@@ -27,6 +27,9 @@ class ByDesignPaymentRecordingJob < ApplicationJob
         recorded_at: Time.current
       )
       Rails.logger.info("[ByDesignPaymentRecordingJob] Successfully recorded all payments")
+
+      # Post the order to move from Entered to Posted status
+      post_order_if_eligible
     else
       handle_recording_failure(results)
     end
@@ -131,6 +134,28 @@ private
       "country_code" => address["country_code"],
       "postal_code" => address["postal_code"],
     }
+  end
+
+  def post_order_if_eligible
+    unless @moola_payment.should_post_order?
+      Rails.logger.info("[ByDesignPaymentRecordingJob] Order not eligible for posting: " \
+                        "kyc=#{@moola_payment.kyc_status}, has_cash=#{has_cash_payment?}")
+      return
+    end
+
+    result = ByDesignPaymentService.post_order(order_id: @moola_payment.bydesign_order_id)
+
+    if result[:success]
+      @moola_payment.update!(order_posted_at: Time.current)
+      Rails.logger.info("[ByDesignPaymentRecordingJob] Order #{@moola_payment.bydesign_order_id} posted successfully")
+    else
+      # Log but don't fail the job - payments were recorded successfully
+      Rails.logger.error("[ByDesignPaymentRecordingJob] Failed to post order #{@moola_payment.bydesign_order_id}: #{result[:error]}")
+    end
+  end
+
+  def has_cash_payment?
+    @moola_payment.payment_details.any? { |pd| pd["type"] == "LOAD_FUNDS_VIA_CASH" }
   end
 
   def handle_recording_failure(results)

--- a/app/models/moola_payment.rb
+++ b/app/models/moola_payment.rb
@@ -67,6 +67,21 @@ class MoolaPayment < ApplicationRecord
     kyc_status == "APPROVE"
   end
 
+  # Determine if the order should be posted after payment recording.
+  # Returns false if any payment is cash (stays Entered until cash received).
+  # Returns false if KYC is not APPROVE.
+  # Returns true only when all payments are Success and KYC is APPROVE.
+  def should_post_order?
+    return false unless kyc_status == "APPROVE"
+    return false if payment_details.blank?
+
+    # Cash payments keep order in Entered status
+    return false if payment_details.any? { |pd| pd["type"] == "LOAD_FUNDS_VIA_CASH" }
+
+    # All payments must be Success
+    payment_details.all? { |pd| pd["status"] == "Success" }
+  end
+
   def total_amount
     payment_details.sum { |pd| pd["amount"].to_f }
   end

--- a/app/services/by_design_payment_service.rb
+++ b/app/services/by_design_payment_service.rb
@@ -105,6 +105,12 @@ class ByDesignPaymentService
       )
     end
 
+    # Post an order to move it from Entered to Posted status
+    # This should be called after all payments are successfully recorded
+    def post_order(order_id:)
+      new.post_order(order_id: order_id)
+    end
+
     # Check if a payment should be skipped (not recorded)
     def should_skip_payment?(payment_detail)
       payment_detail["status"] == "Declined"
@@ -126,6 +132,25 @@ class ByDesignPaymentService
     def supported_payment_type?(payment_type)
       SUPPORTED_PAYMENT_TYPES.include?(payment_type)
     end
+  end
+
+  def post_order(order_id:)
+    Rails.logger.info("[ByDesignPaymentService] Posting order: OrderID=#{order_id}")
+
+    response = self.class.post(
+      "/api/order/Order/#{order_id}/Post",
+      headers: headers,
+      timeout: DEFAULT_TIMEOUT
+    )
+
+    Rails.logger.info("[ByDesignPaymentService] Post order response: code=#{response.code}")
+    parse_response(response)
+  rescue Net::OpenTimeout, Net::ReadTimeout => e
+    Rails.logger.error("[ByDesignPaymentService] Post order timeout: #{e.class} - #{e.message}")
+    { success: false, error: "Request timeout: #{e.message}", response: nil }
+  rescue StandardError => e
+    Rails.logger.error("[ByDesignPaymentService] Post order error: #{e.class} - #{e.message}")
+    { success: false, error: e.message, response: nil }
   end
 
   def record_payment(order_id:, payment_detail:, p2m_data: {}, card_details: {}, billing_address: {}, kyc_status: nil)

--- a/db/migrate/20260410000001_add_order_posted_at_to_moola_payments.rb
+++ b/db/migrate/20260410000001_add_order_posted_at_to_moola_payments.rb
@@ -1,0 +1,5 @@
+class AddOrderPostedAtToMoolaPayments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :moola_payments, :order_posted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_21_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_10_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_21_000001) do
     t.datetime "recorded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "order_posted_at"
     t.index ["bydesign_order_id"], name: "index_moola_payments_on_bydesign_order_id"
     t.index ["cart_token"], name: "index_moola_payments_on_cart_token", unique: true
     t.index ["fluid_order_id"], name: "index_moola_payments_on_fluid_order_id"

--- a/test/jobs/by_design_payment_recording_job_test.rb
+++ b/test/jobs/by_design_payment_recording_job_test.rb
@@ -36,6 +36,13 @@ describe ByDesignPaymentRecordingJob do
           headers: { "Content-Type" => "application/json" }
         )
 
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
       ByDesignPaymentRecordingJob.perform_now(payment.id)
 
       payment.reload
@@ -215,6 +222,13 @@ describe ByDesignPaymentRecordingJob do
           headers: { "Content-Type" => "application/json" }
         )
 
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
       ByDesignPaymentRecordingJob.perform_now(payment.id)
 
       # Two API calls should be made
@@ -246,6 +260,13 @@ describe ByDesignPaymentRecordingJob do
       request_body = nil
       stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
         .with { |request| request_body = JSON.parse(request.body); true }
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -297,6 +318,13 @@ describe ByDesignPaymentRecordingJob do
           headers: { "Content-Type" => "application/json" }
         )
 
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
       ByDesignPaymentRecordingJob.perform_now(payment.id)
 
       # Verify card-specific fields per API documentation
@@ -306,6 +334,151 @@ describe ByDesignPaymentRecordingJob do
       _(request_body["ProcessorSpecificDetail3"]).must_equal "load_funds_via_card"       # payment type (lowercase)
       # Detail23: Freedom payment type label
       _(request_body["ProcessorSpecificDetail23"]).must_equal "load_funds_via_card"
+    end
+
+    it "posts order after successful recording when eligible" do
+      payment = MoolaPayment.create!(
+        cart_token: "post-order-test",
+        invoice_number: "NULF-CT:post-order-test",
+        bydesign_order_id: "12345",
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "id" => "PAY123", "status" => "Success" },
+        ],
+        status: :matched
+      )
+
+      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      post_stub = stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ByDesignPaymentRecordingJob.perform_now(payment.id)
+
+      assert_requested(post_stub, times: 1)
+      payment.reload
+      _(payment.status).must_equal "recorded"
+      _(payment.order_posted_at).wont_be_nil
+    end
+
+    it "does not post order when payment has cash type" do
+      payment = MoolaPayment.create!(
+        cart_token: "cash-no-post",
+        invoice_number: "NULF-CT:cash-no-post",
+        bydesign_order_id: "12345",
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "LOAD_FUNDS_VIA_CASH", "amount" => "100.00", "id" => "PAY123", "status" => "Success" },
+        ],
+        status: :matched
+      )
+
+      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ByDesignPaymentRecordingJob.perform_now(payment.id)
+
+      payment.reload
+      _(payment.status).must_equal "recorded"
+      _(payment.order_posted_at).must_be_nil
+    end
+
+    it "does not post order when payment has Pending status" do
+      payment = MoolaPayment.create!(
+        cart_token: "pending-no-post",
+        invoice_number: "NULF-CT:pending-no-post",
+        bydesign_order_id: "12345",
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "id" => "PAY123", "status" => "Pending" },
+        ],
+        status: :matched
+      )
+
+      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ByDesignPaymentRecordingJob.perform_now(payment.id)
+
+      payment.reload
+      _(payment.status).must_equal "recorded"
+      _(payment.order_posted_at).must_be_nil
+    end
+
+    it "records payment but does not fail when post order API fails" do
+      payment = MoolaPayment.create!(
+        cart_token: "post-fail-test",
+        invoice_number: "NULF-CT:post-fail-test",
+        bydesign_order_id: "12345",
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "id" => "PAY123", "status" => "Success" },
+        ],
+        status: :matched
+      )
+
+      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 500,
+          body: "Internal Server Error"
+        )
+
+      ByDesignPaymentRecordingJob.perform_now(payment.id)
+
+      payment.reload
+      # Payment still recorded even though post failed
+      _(payment.status).must_equal "recorded"
+      _(payment.order_posted_at).must_be_nil
+    end
+
+    it "does not post order when KYC is REVIEW" do
+      payment = MoolaPayment.create!(
+        cart_token: "kyc-review-no-post",
+        invoice_number: "NULF-CT:kyc-review-no-post",
+        bydesign_order_id: "12345",
+        kyc_status: "REVIEW",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "id" => "PAY123", "status" => "Success" },
+        ],
+        status: :matched
+      )
+
+      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ByDesignPaymentRecordingJob.perform_now(payment.id)
+
+      payment.reload
+      _(payment.status).must_equal "recorded"
+      _(payment.order_posted_at).must_be_nil
     end
 
     it "discards job when payment record not found" do

--- a/test/models/moola_payment_test.rb
+++ b/test/models/moola_payment_test.rb
@@ -201,6 +201,90 @@ describe MoolaPayment do
     end
   end
 
+  describe "#should_post_order?" do
+    it "returns true when all payments are Success and KYC is APPROVE" do
+      payment = MoolaPayment.new(
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "50.00", "status" => "Success" },
+          { "type" => "LOAD_FUNDS_VIA_CARD", "amount" => "50.00", "status" => "Success" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal true
+    end
+
+    it "returns false when KYC is REVIEW" do
+      payment = MoolaPayment.new(
+        kyc_status: "REVIEW",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "status" => "Success" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when KYC is DECLINE" do
+      payment = MoolaPayment.new(
+        kyc_status: "DECLINE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "status" => "Success" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when any payment is cash" do
+      payment = MoolaPayment.new(
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "50.00", "status" => "Success" },
+          { "type" => "LOAD_FUNDS_VIA_CASH", "amount" => "50.00", "status" => "Success" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when any payment is Pending" do
+      payment = MoolaPayment.new(
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "50.00", "status" => "Success" },
+          { "type" => "LOAD_FUNDS_VIA_CARD", "amount" => "50.00", "status" => "Pending" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when any payment is Declined" do
+      payment = MoolaPayment.new(
+        kyc_status: "APPROVE",
+        payment_details: [
+          { "type" => "uwallet", "amount" => "50.00", "status" => "Success" },
+          { "type" => "LOAD_FUNDS_VIA_CARD", "amount" => "50.00", "status" => "Declined" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when payment_details is blank" do
+      payment = MoolaPayment.new(
+        kyc_status: "APPROVE",
+        payment_details: []
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+
+    it "returns false when KYC is nil" do
+      payment = MoolaPayment.new(
+        kyc_status: nil,
+        payment_details: [
+          { "type" => "uwallet", "amount" => "100.00", "status" => "Success" },
+        ]
+      )
+      _(payment.should_post_order?).must_equal false
+    end
+  end
+
   describe "#total_amount" do
     it "sums all payment amounts" do
       payment = MoolaPayment.new(

--- a/test/services/by_design_payment_service_test.rb
+++ b/test/services/by_design_payment_service_test.rb
@@ -483,6 +483,73 @@ describe ByDesignPaymentService do
     end
   end
 
+  describe "#post_order" do
+    it "makes POST request to the correct endpoint and succeeds" do
+      stub = stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      result = ByDesignPaymentService.post_order(order_id: 12345)
+
+      assert_requested(stub, times: 1)
+      _(result[:success]).must_equal true
+      _(result[:error]).must_be_nil
+    end
+
+    it "handles API error response" do
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 400,
+          body: { "Message" => "Order not found" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      result = ByDesignPaymentService.post_order(order_id: 12345)
+
+      _(result[:success]).must_equal false
+      _(result[:error]).must_match(/Order not found/)
+    end
+
+    it "handles timeout errors" do
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_timeout
+
+      result = ByDesignPaymentService.post_order(order_id: 12345)
+
+      _(result[:success]).must_equal false
+      _(result[:error]).must_match(/timeout/i)
+    end
+
+    it "handles server errors" do
+      stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .to_return(
+          status: 500,
+          body: "Internal Server Error"
+        )
+
+      result = ByDesignPaymentService.post_order(order_id: 12345)
+
+      _(result[:success]).must_equal false
+    end
+
+    it "includes authorization headers" do
+      stub = stub_request(:post, /\/api\/order\/Order\/12345\/Post/)
+        .with(headers: { "Authorization" => /^Basic / })
+        .to_return(
+          status: 200,
+          body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ByDesignPaymentService.post_order(order_id: 12345)
+
+      assert_requested(stub, times: 1)
+    end
+  end
+
   describe "response parsing" do
     let(:service) { ByDesignPaymentService.new }
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/order/Order/{OrderID}/Post` call after all payments are recorded successfully
- Orders transition from **Entered** → **Posted** status, enabling fulfillment
- Adds `should_post_order?` to `MoolaPayment` model with eligibility checks
- Adds `order_posted_at` timestamp column to track when orders were posted

## Context
Per the ByDesign API documentation, orders start in "Entered" status when created. The shopping cart application is responsible for calling the Post Order API to move orders to "Posted" (ready for fulfillment). This was not implemented, causing all orders to remain in "Entered" status.

## Post Order Rules (from API docs)
Orders are posted when:
- ALL `payment_details` have `status = "Success"`
- `kycStatus = "APPROVE"`

Orders remain in Entered when:
- Any payment has `status = "Pending"` or `"Declined"`
- `kycStatus = "REVIEW"` or `"DECLINE"`
- Any payment is `LOAD_FUNDS_VIA_CASH` (stays Entered until cash received at offices)

## Design decisions
- Post failure is **logged but does not fail the job** — payments were already recorded successfully
- `order_posted_at` timestamp tracks when the post happened for debugging
- Cash payments are explicitly excluded per API docs (cash must be received physically)

## Test plan
- [x] 108 tests pass across service, model, and job test files
- [ ] Place test order with all-Success payments + KYC APPROVE → verify order transitions to Posted
- [ ] Place test order with cash payment → verify order stays in Entered
- [ ] Place test order with KYC REVIEW → verify order stays in Entered
- [ ] Verify post failure doesn't prevent payment recording from succeeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)