### PR TITLE
fix: use correct ByDesign payment API endpoint

### DIFF
--- a/app/services/by_design_payment_service.rb
+++ b/app/services/by_design_payment_service.rb
@@ -157,7 +157,7 @@ class ByDesignPaymentService
     Rails.logger.debug("[ByDesignPaymentService] Payload: #{payload.to_json}")
 
     response = self.class.post(
-      "/api/order/Payment/CreditCard/Save",
+      "/api/Personal/Order/Payment/CreditCard/Save",
       headers: headers,
       body: payload.to_json,
       timeout: DEFAULT_TIMEOUT
@@ -432,7 +432,7 @@ private
   def parse_response(response)
     body = parse_json_safely(response.body)
 
-    # The /api/order/Payment/CreditCard/Save endpoint returns:
+    # The /api/Personal/Order/Payment/CreditCard/Save endpoint returns:
     # - 201 with { "Result": {...}, "IsSuccessful": true } on success
     # - 400/500 with { "IsSuccessful": false, "Message": "..." } on error
     if response.code == 200 || response.code == 201

--- a/test/jobs/by_design_payment_recording_job_test.rb
+++ b/test/jobs/by_design_payment_recording_job_test.rb
@@ -29,7 +29,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -78,7 +78,7 @@ describe ByDesignPaymentRecordingJob do
       )
 
       # Only one API call should be made (for PAY1, not PAY2)
-      stub = stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub = stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -125,7 +125,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "Result" => { "IsSuccessful" => false, "Message" => "Order not found" } }.to_json,
@@ -154,7 +154,7 @@ describe ByDesignPaymentRecordingJob do
         bydesign_recording_attempts: 4  # One below max
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "Result" => { "IsSuccessful" => false, "Message" => "Persistent error" } }.to_json,
@@ -183,7 +183,7 @@ describe ByDesignPaymentRecordingJob do
 
       # Capture the request body to verify kyc_status is being used
       request_body = nil
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .with { |request| request_body = JSON.parse(request.body); true }
         .to_return(
           status: 200,
@@ -215,7 +215,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub = stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub = stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -258,7 +258,7 @@ describe ByDesignPaymentRecordingJob do
       )
 
       request_body = nil
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .with { |request| request_body = JSON.parse(request.body); true }
         .to_return(
           status: 200,
@@ -310,7 +310,7 @@ describe ByDesignPaymentRecordingJob do
       )
 
       request_body = nil
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .with { |request| request_body = JSON.parse(request.body); true }
         .to_return(
           status: 200,
@@ -348,7 +348,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -382,7 +382,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -408,7 +408,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -434,7 +434,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,
@@ -467,7 +467,7 @@ describe ByDesignPaymentRecordingJob do
         status: :matched
       )
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 200,
           body: { "IsSuccessful" => true, "Result" => { "ID" => "12345" } }.to_json,

--- a/test/services/by_design_payment_service_test.rb
+++ b/test/services/by_design_payment_service_test.rb
@@ -92,7 +92,7 @@ describe ByDesignPaymentService do
         "order_reference" => "TKW2BRL2OP",
       }
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .with { |request|
           body = JSON.parse(request.body)
           # Verify correct field mappings per API docs
@@ -135,7 +135,7 @@ describe ByDesignPaymentService do
         "order_reference" => "TKW2BRL2OP",
       }
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .with { |request|
           body = JSON.parse(request.body)
           # Wallet payments should NOT have card fields
@@ -169,7 +169,7 @@ describe ByDesignPaymentService do
         "status" => "Success",
       }
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_return(
           status: 500,
           body: "Internal Server Error"
@@ -193,7 +193,7 @@ describe ByDesignPaymentService do
         "status" => "Success",
       }
 
-      stub_request(:post, /\/api\/order\/Payment\/CreditCard\/Save/)
+      stub_request(:post, /\/api\/Personal\/Order\/Payment\/CreditCard\/Save/)
         .to_timeout
 
       result = ByDesignPaymentService.record_payment(


### PR DESCRIPTION
## Summary
- Changes payment recording endpoint from `/api/order/Payment/CreditCard/Save` to `/api/Personal/Order/Payment/CreditCard/Save`

## Context
The previous endpoint (`/api/order/...`) only accepts 17 fields and does **not** support:
- `ProcessorSpecificDetail1-5` (including Detail3 used for payment type labels)
- `PaymentStatusTypeID`
- `PromissoryAmount`
- `PersistentToken` / `ProfileIDUsedForProcessor`
- `PaymentToken`

All of these fields were being silently dropped, which is why:
- Freedom showed "Credit Card" for all payment types (Detail3 was never stored)
- Payment status mapping wasn't working
- Promissory amounts weren't being set

The correct endpoint (`/api/Personal/Order/...`) accepts all 26 fields per the [API docs](https://webapi.bydesign.com/NewULifeSandbox/Help/Api/POST-api-Personal-Order-Payment-CreditCard-Save) and the Moola/ByDesign integration documentation.

## Test plan
- [x] All 63 tests pass (service + job)
- [ ] Place test order with multiple payment types — verify Detail3/Detail23 values are stored in ByDesign
- [ ] Verify payment type labels display correctly in Freedom
- [ ] Verify PaymentStatusTypeID and PromissoryAmount are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)