### PR TITLE
fix: prevent duplicate payment recordings from repeated webhooks

### DIFF
--- a/app/jobs/fluid_order_external_id_updated_job.rb
+++ b/app/jobs/fluid_order_external_id_updated_job.rb
@@ -39,6 +39,12 @@ class FluidOrderExternalIdUpdatedJob < WebhookEventJob
       return
     end
 
+    if moola_payment.recorded? || moola_payment.failed?
+      Rails.logger.info("[FluidOrderExternalIdUpdatedJob] Skipping update for terminal payment: " \
+                        "cart_token=#{moola_payment.cart_token}, status=#{moola_payment.status}")
+      return
+    end
+
     # Update with Fluid order data
     moola_payment.assign_attributes(
       fluid_order_id: fluid_order_id,

--- a/app/jobs/moola_p2m_webhook_job.rb
+++ b/app/jobs/moola_p2m_webhook_job.rb
@@ -78,6 +78,12 @@ private
   end
 
   def update_payment_record(payment)
+    if payment.recorded? || payment.failed?
+      Rails.logger.info("[MoolaP2mWebhookJob] Skipping update for terminal payment: " \
+                        "cart_token=#{payment.cart_token}, status=#{payment.status}")
+      return
+    end
+
     payment.assign_attributes(
       moola_transaction_id: @payload[:transaction_id] || @payload[:id],
       kyc_status: kyc_status,
@@ -93,6 +99,12 @@ private
   # Update card details from load_funds_via_card webhook
   # These webhooks contain: card_number_last4, expiry_date, payment_instrument_uuid
   def update_card_details(payment)
+    if payment.recorded? || payment.failed?
+      Rails.logger.info("[MoolaP2mWebhookJob] Skipping card update for terminal payment: " \
+                        "cart_token=#{payment.cart_token}, status=#{payment.status}")
+      return
+    end
+
     card_details = extract_card_details
     return if card_details.empty?
 

--- a/app/models/moola_payment.rb
+++ b/app/models/moola_payment.rb
@@ -39,9 +39,19 @@ class MoolaPayment < ApplicationRecord
     match ? match[1] : nil
   end
 
-  # Determine the correct status based on current state
-  # Call this after updating payment data to ensure status is correct
+  # Determine the correct status based on current state.
+  # Call this after updating payment data to ensure status is correct.
+  #
+  # Preserves terminal states (:recorded, :failed) to prevent duplicate
+  # ByDesign recordings when a second webhook arrives after payments
+  # were already recorded.
   def determine_status
+    # Never regress from terminal states — payments already sent to ByDesign
+    return status.to_sym if recorded? || failed?
+
+    # Recording in progress — don't interfere
+    return :recording if recording?
+
     return :kyc_declined if kyc_status == "DECLINE"
     return :kyc_pending if kyc_status == "REVIEW"
 

--- a/app/services/by_design_payment_service.rb
+++ b/app/services/by_design_payment_service.rb
@@ -246,10 +246,8 @@ private
       ProcessorSpecificDetail2: autoship_reference,      # autoship_reference if present
       ProcessorSpecificDetail3: normalize_payment_type(payment_type),  # Payment type for differentiation
       ProcessorSpecificDetail4: order_reference,          # order_reference (same as TransactionID)
-
-      # Detail23 is used by Freedom to determine the payment type label
-      # (e.g., "Credit Card", "UWallet Transfer", "UWallet", etc.)
-      ProcessorSpecificDetail23: normalize_payment_type(payment_type),
+      # Note: ProcessorSpecificDetail3 maps to detail23 in ByDesign's DB,
+      # which Freedom reads for payment type labels. No separate Detail23 field needed.
     }
   end
 

--- a/test/jobs/by_design_payment_recording_job_test.rb
+++ b/test/jobs/by_design_payment_recording_job_test.rb
@@ -284,7 +284,7 @@ describe ByDesignPaymentRecordingJob do
       _(request_body["ProcessorSpecificDetail2"]).must_equal "G2XYS6ZBBZ"   # autoship_reference
       _(request_body["ProcessorSpecificDetail3"]).must_equal "p2m"           # uwallet maps to p2m
       _(request_body["ProcessorSpecificDetail4"]).must_equal "TKW2BRL2OP"   # order_reference
-      _(request_body["ProcessorSpecificDetail23"]).must_equal "p2m"        # Detail23: Freedom maps p2m to UWallet label
+      _(request_body.key?("ProcessorSpecificDetail23")).must_equal false   # Detail3 maps to detail23 in DB
     end
 
     it "sends correct card fields for LOAD_FUNDS_VIA_CARD payments" do
@@ -332,8 +332,7 @@ describe ByDesignPaymentRecordingJob do
       _(request_body["Last4CCNumber"]).must_equal "7999"                                  # card_number_last4
       _(request_body["ExpirationDateMMYY"]).must_equal "0829"                            # expiry_date converted
       _(request_body["ProcessorSpecificDetail3"]).must_equal "load_funds_via_card"       # payment type (lowercase)
-      # Detail23: Freedom payment type label
-      _(request_body["ProcessorSpecificDetail23"]).must_equal "load_funds_via_card"
+      _(request_body.key?("ProcessorSpecificDetail23")).must_equal false                # Detail3 maps to detail23 in DB
     end
 
     it "posts order after successful recording when eligible" do

--- a/test/models/moola_payment_test.rb
+++ b/test/models/moola_payment_test.rb
@@ -144,6 +144,42 @@ describe MoolaPayment do
       )
       _(payment.determine_status).must_equal :pending
     end
+
+    it "preserves recorded status even when all data present" do
+      payment = MoolaPayment.new(
+        cart_token: "test",
+        invoice_number: "NULF-CT:test",
+        kyc_status: "APPROVE",
+        bydesign_order_id: "12345",
+        payment_details: [ { "type" => "uwallet", "amount" => "100" } ],
+        status: :recorded
+      )
+      _(payment.determine_status).must_equal :recorded
+    end
+
+    it "preserves failed status even when all data present" do
+      payment = MoolaPayment.new(
+        cart_token: "test",
+        invoice_number: "NULF-CT:test",
+        kyc_status: "APPROVE",
+        bydesign_order_id: "12345",
+        payment_details: [ { "type" => "uwallet", "amount" => "100" } ],
+        status: :failed
+      )
+      _(payment.determine_status).must_equal :failed
+    end
+
+    it "preserves recording status to prevent interference" do
+      payment = MoolaPayment.new(
+        cart_token: "test",
+        invoice_number: "NULF-CT:test",
+        kyc_status: "APPROVE",
+        bydesign_order_id: "12345",
+        payment_details: [ { "type" => "uwallet", "amount" => "100" } ],
+        status: :recording
+      )
+      _(payment.determine_status).must_equal :recording
+    end
   end
 
   describe "#ready_to_record?" do
@@ -418,6 +454,43 @@ describe MoolaPayment do
       result = payment.update_status_and_enqueue_if_ready!
 
       _(result).must_equal false
+    end
+
+    it "does not re-enqueue when already recorded" do
+      payment = MoolaPayment.create!(
+        cart_token: "already-recorded-test",
+        invoice_number: "NULF-CT:already-recorded-test",
+        kyc_status: "APPROVE",
+        bydesign_order_id: "12345",
+        payment_details: [ { "type" => "uwallet", "amount" => "100" } ],
+        status: :recorded,
+        recorded_at: 1.minute.ago
+      )
+
+      assert_no_enqueued_jobs(only: ByDesignPaymentRecordingJob) do
+        payment.update_status_and_enqueue_if_ready!
+      end
+
+      # Status must stay recorded
+      _(payment.reload.status).must_equal "recorded"
+    end
+
+    it "does not re-enqueue when failed" do
+      payment = MoolaPayment.create!(
+        cart_token: "already-failed-test",
+        invoice_number: "NULF-CT:already-failed-test",
+        kyc_status: "APPROVE",
+        bydesign_order_id: "12345",
+        payment_details: [ { "type" => "uwallet", "amount" => "100" } ],
+        status: :failed,
+        bydesign_recording_attempts: 5
+      )
+
+      assert_no_enqueued_jobs(only: ByDesignPaymentRecordingJob) do
+        payment.update_status_and_enqueue_if_ready!
+      end
+
+      _(payment.reload.status).must_equal "failed"
     end
 
     it "does not enqueue job when not ready to record" do

--- a/test/services/by_design_payment_service_test.rb
+++ b/test/services/by_design_payment_service_test.rb
@@ -106,7 +106,7 @@ describe ByDesignPaymentService do
           body["ProcessorSpecificDetail2"] == "G2XYS6ZBBZ" &&         # autoship_reference
           body["ProcessorSpecificDetail3"] == "load_funds_via_card" && # payment type (lowercase)
           body["ProcessorSpecificDetail4"] == "TKW2BRL2OP" &&         # order_reference
-          body["ProcessorSpecificDetail23"] == "load_funds_via_card"   # Detail23: Freedom payment type label
+          !body.key?("ProcessorSpecificDetail23")                     # removed: Detail3 maps to detail23 in DB
         }
         .to_return(
           status: 200,
@@ -143,7 +143,7 @@ describe ByDesignPaymentService do
           !body.key?("Last4CCNumber") &&
           !body.key?("ExpirationDateMMYY") &&
           body["ProcessorSpecificDetail3"] == "p2m" &&
-          body["ProcessorSpecificDetail23"] == "p2m"
+          !body.key?("ProcessorSpecificDetail23")
         }
         .to_return(
           status: 200,
@@ -338,7 +338,7 @@ describe ByDesignPaymentService do
         _(payload[:ProcessorSpecificDetail2]).must_equal "G2XYS6ZBBZ"       # autoship_reference
         _(payload[:ProcessorSpecificDetail3]).must_equal "p2m"               # uwallet maps to p2m
         _(payload[:ProcessorSpecificDetail4]).must_equal "TKW2BRL2OP"       # order_reference
-        _(payload[:ProcessorSpecificDetail23]).must_equal "p2m"            # Detail23: Freedom maps p2m to UWallet
+        _(payload.key?(:ProcessorSpecificDetail23)).must_equal false       # Detail3 maps to detail23 in DB
       end
 
       it "uses promissory amount for Pending payments" do
@@ -386,7 +386,7 @@ describe ByDesignPaymentService do
         _(payload[:PromissoryAmount]).must_equal 50.0
         _(payload[:PaymentStatusTypeID]).must_equal 6  # Pending
         _(payload[:ProcessorSpecificDetail3]).must_equal "load_funds_via_cash"
-        _(payload[:ProcessorSpecificDetail23]).must_equal "load_funds_via_cash"
+        _(payload.key?(:ProcessorSpecificDetail23)).must_equal false
       end
     end
 


### PR DESCRIPTION
## Summary
- `determine_status` now preserves terminal states (`:recorded`, `:failed`, `:recording`) — prevents status regression when late webhooks arrive
- Removes `ProcessorSpecificDetail23` from payload — ByDesign maps `ProcessorSpecificDetail3` to `detail23` internally (offset by 20), so it was redundant and not a valid API field

## Root cause
When UPayments sends multiple P2M webhooks for the same order (~50s apart with updated statuses), `determine_status` was overwriting `:recorded` back to `:matched`. This bypassed the lock guard in `update_status_and_enqueue_if_ready!`, causing a second `ByDesignPaymentRecordingJob` to run and create **duplicate payments** in ByDesign.

Flow before fix:
1. First webhook → status: pending → matched → recording → **recorded** ✓
2. Second webhook → `determine_status` returns `:matched` → overwrites **recorded** → lock guard passes → second recording job → **duplicates** ✗

Flow after fix:
1. First webhook → status: pending → matched → recording → **recorded** ✓
2. Second webhook → `determine_status` returns `:recorded` (preserved) → no re-enqueue ✓

## Also fixed
`ProcessorSpecificDetail23` removed from payload. ByDesign's internal DB stores `ProcessorSpecificDetail3` as `detail23` (all ProcessorSpecificDetail fields are offset by +20 in storage). Confirmed by ByDesign API response showing `detail23: "load_funds_via_cash"` matching our `ProcessorSpecificDetail3` value.

## Test plan
- [x] 202 tests pass (0 failures, 0 errors)
- [x] Rubocop clean
- [ ] Place test order — verify only 1 set of payments created in ByDesign even if multiple webhooks fire
- [ ] Verify `detail23` still shows correct payment type labels in Freedom

🤖 Generated with [Claude Code](https://claude.com/claude-code)